### PR TITLE
Template url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ buildNumber.properties
 .project
 .classpath
 .settings
+### Idea IDE
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ To create or update a stack in CloudFormation (bulk create/modify resources in A
         <region>ap-southeast-2</region>
         <stackName>myStack</stackName>
         <template>src/main/aws/cloudformation.yaml</template>
+        <!--
+        or use already uploaded s3 artifact
+        <templateUrl>https://bucketName.s3.amazonaws.com/filename.yml</templateUrl>
+        -->
         <parameters>
             <mode>dev</mode>
             <version>6.01</version>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <aws.sdk.version>1.11.224</aws.sdk.version>
+        <aws.sdk.version>1.11.271</aws.sdk.version>
         <scm.url>scm:git:https://github.com/davidmoten/aws-maven-plugin.git</scm.url>
     </properties>
 

--- a/src/main/java/com/github/davidmoten/aws/maven/CloudFormationDeployMojo.java
+++ b/src/main/java/com/github/davidmoten/aws/maven/CloudFormationDeployMojo.java
@@ -40,6 +40,9 @@ public final class CloudFormationDeployMojo extends AbstractMojo {
     @Parameter(property = "stackTemplate")
     private File template;
 
+    @Parameter(property = "templateUrl")
+    private String templateUrl;
+
     @Parameter(property = "intervalSeconds", defaultValue="5")
     private int intervalSeconds;
 
@@ -72,11 +75,16 @@ public final class CloudFormationDeployMojo extends AbstractMojo {
         AwsKeyPair keys = Util.getAwsKeyPair(serverId, awsAccessKey, awsSecretAccessKey, settings,
                 decrypter);
         byte[] bytes;
-        try {
-            bytes = Files.readAllBytes(template.toPath());
-        } catch (IOException e) {
-            throw new MojoFailureException(
-                    "could not read template=" + template + ": " + e.getMessage(), e);
+
+        if (templateUrl == null) {
+            try {
+                bytes = Files.readAllBytes(template.toPath());
+            } catch (IOException e) {
+                throw new MojoFailureException(
+                        "could not read template=" + template + ": " + e.getMessage(), e);
+            }
+        } else {
+            bytes = new byte[0];
         }
 
         // Note UTF-16 is possible also if starts with byte-order mark, see yaml
@@ -84,7 +92,7 @@ public final class CloudFormationDeployMojo extends AbstractMojo {
         // complains!
         String templateBody = new String(bytes, StandardCharsets.UTF_8);
         deployer.deploy(keys, region, stackName, templateBody, parameters,
-                intervalSeconds, proxy);
+                intervalSeconds, proxy, templateUrl);
     }
 
 }


### PR DESCRIPTION
Possibility for using template url from s3 added. AWS have restriction on template size for cloudfortmation deploy request - 51,200 bytes. But for template on s3 max size is 460,800 bytes. So with newly added url template paramter you can deploy larger stacks.

It would be nice if you increase a version and publish it to the maven. Feel free to ask any questions.
