### PR TITLE
Add alias to lambda deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Add this to the `<plugins>` section of your pom.xml:
         <awsSecretAccessKey>${env.AWS_SECRET_ACCESS_KEY}</awsSecretAccessKey>
         <artifact>${project.build.directory}/my-artifact.war</artifact>
         <functionName>myFunction</functionName>
+        <!-- optional functionAlias, if included an alias for the new lambda version is created -->
+        <functionAlias>${project.version}-${maven.build.timestamp}</functionAlias>
         <region>ap-southeast-2</region>
         <!-- optional proxy config -->
         <httpsProxyHost>proxy.amsa.gov.au</httpsProxyHost>

--- a/src/main/java/com/github/davidmoten/aws/maven/LambdaDeployMojo.java
+++ b/src/main/java/com/github/davidmoten/aws/maven/LambdaDeployMojo.java
@@ -25,6 +25,9 @@ public final class LambdaDeployMojo extends AbstractMojo {
     @Parameter(property = "functionName")
     private String functionName;
 
+    @Parameter(property = "functionAlias")
+    private String functionAlias;
+
     @Parameter(property = "artifact")
     private String artifact;
 
@@ -59,7 +62,7 @@ public final class LambdaDeployMojo extends AbstractMojo {
         LambdaDeployer deployer = new LambdaDeployer(getLog());
         AwsKeyPair keys = Util.getAwsKeyPair(serverId, awsAccessKey, awsSecretAccessKey, settings,
                 decrypter);
-        deployer.deploy(keys, region, artifact, functionName, proxy);
+        deployer.deploy(keys, region, artifact, functionName, functionAlias, proxy);
     }
 
 }

--- a/src/main/java/com/github/davidmoten/aws/maven/LambdaDeployer.java
+++ b/src/main/java/com/github/davidmoten/aws/maven/LambdaDeployer.java
@@ -52,12 +52,16 @@ class LambdaDeployer {
         log.info("deployed in " + (System.currentTimeMillis() - t) + "ms");
         Optional<String> optionalFunctionAlias = Optional.ofNullable(functionAlias);
         if (optionalFunctionAlias.isPresent()) {
+            // ailas only likes underscores, have to strip out other characters if they are present
+            String sanitisedFunctionalAlias = optionalFunctionAlias.get()
+                    .replaceAll("[-\\.]", "_")
+                    .replaceAll(":", "");
             CreateAliasResult createAliasResult = lambda.createAlias(
                 new CreateAliasRequest()
                     .withFunctionVersion(updateFunctionCodeResult.getVersion())
                     .withFunctionName(functionName)
-                    .withName(optionalFunctionAlias.get()));
-            log.info("created alias=" + optionalFunctionAlias.get() + " to functionName=" + functionName + " for version=" + updateFunctionCodeResult.getVersion());
+                    .withName(sanitisedFunctionalAlias));
+            log.info("created alias=" + sanitisedFunctionalAlias + " to functionName=" + functionName + " for version=" + updateFunctionCodeResult.getVersion());
         }
     }
 


### PR DESCRIPTION
Hi!

Thanks for your excellent plugin, I have been using it for beanstalk and lambda deployments.  When I do a deployLambda I also like to create an alias so it makes it easy to roll back if you need to.

Please consider my changes.

Thanks!

Jeff Sheehan