### PR TITLE
A new value was added to capabilities enum

### DIFF
--- a/src/main/java/com/github/davidmoten/aws/maven/CloudFormationDeployer.java
+++ b/src/main/java/com/github/davidmoten/aws/maven/CloudFormationDeployer.java
@@ -77,6 +77,7 @@ final class CloudFormationDeployer {
                     .withStackName(stackName) //
                     .withParameters(params) //
                     .withCapabilities(Capability.CAPABILITY_IAM) //
+                    .withCapabilities(Capability.CAPABILITY_AUTO_EXPAND) //
                     .withCapabilities(Capability.CAPABILITY_NAMED_IAM);
             if (templateUrl != null) {
                 createStackRequest = createStackRequest.withTemplateURL(templateUrl); //
@@ -91,6 +92,7 @@ final class CloudFormationDeployer {
                         .withStackName(stackName) //
                         .withParameters(params) //
                         .withCapabilities(Capability.CAPABILITY_IAM) //
+                        .withCapabilities(Capability.CAPABILITY_AUTO_EXPAND) //
                         .withCapabilities(Capability.CAPABILITY_NAMED_IAM);
                 if (templateUrl != null) {
                     updateStackRequest = updateStackRequest.withTemplateURL(templateUrl); //


### PR DESCRIPTION
A cloudformation reports en error when stack with Fn::Transform and Fn::Include is deployed with out CAPABILITY_AUTO_EXPAND parameter

See https://docs.aws.amazon.com/en_us/AWSCloudFormation/latest/APIReference/API_CreateStack.html