### PR TITLE
Add destroyCf goal that deletes CloudFormation stack.

### DIFF
--- a/src/main/java/com/github/davidmoten/aws/maven/CloudFormationDeployer.java
+++ b/src/main/java/com/github/davidmoten/aws/maven/CloudFormationDeployer.java
@@ -8,8 +8,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import org.apache.maven.plugin.logging.Log;
-
 import com.amazonaws.services.cloudformation.AmazonCloudFormation;
 import com.amazonaws.services.cloudformation.model.AmazonCloudFormationException;
 import com.amazonaws.services.cloudformation.model.Capability;
@@ -24,6 +22,7 @@ import com.amazonaws.services.cloudformation.model.Stack;
 import com.amazonaws.services.cloudformation.model.StackStatus;
 import com.amazonaws.services.cloudformation.model.UpdateStackRequest;
 import com.google.common.base.Preconditions;
+import org.apache.maven.plugin.logging.Log;
 
 final class CloudFormationDeployer {
 
@@ -36,20 +35,20 @@ final class CloudFormationDeployer {
     }
 
     public void destroy(String stackName, int intervalSeconds) {
-		cloudFormationClient.deleteStack(
-				new DeleteStackRequest().withStackName(stackName)
-		);
+        cloudFormationClient.deleteStack(
+                new DeleteStackRequest().withStackName(stackName)
+        );
 
-		int statusPollingIntervalMs = intervalSeconds * 1000;
+        int statusPollingIntervalMs = intervalSeconds * 1000;
 
-		// insert blank line into log
-		log.info("");
-		Status result = waitForCompletion(stackName, statusPollingIntervalMs, log);
+        // insert blank line into log
+        log.info("");
+        Status result = waitForCompletion(stackName, statusPollingIntervalMs, log);
 
-		if (!Arrays.asList(StackStatus.DELETE_COMPLETE.toString(), "NO_SUCH_STACK").contains(result.value)) {
-			throw new RuntimeException("delete stack failed: " + result);
-		}
-	}
+        if (!Arrays.asList(StackStatus.DELETE_COMPLETE.toString(), "NO_SUCH_STACK").contains(result.value)) {
+            throw new RuntimeException("delete stack failed: " + result);
+        }
+    }
 
     public void deploy(String stackName, String templateBody,
                        Map<String, String> parameters, int intervalSeconds, String templateUrl) {

--- a/src/main/java/com/github/davidmoten/aws/maven/CloudFormationDeployer.java
+++ b/src/main/java/com/github/davidmoten/aws/maven/CloudFormationDeployer.java
@@ -1,6 +1,7 @@
 package com.github.davidmoten.aws.maven;
 
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +34,22 @@ final class CloudFormationDeployer {
         this.log = log;
         this.cloudFormationClient = cloudFormationClient;
     }
+
+    public void destroy(String stackName, int intervalSeconds) {
+		cloudFormationClient.deleteStack(
+				new DeleteStackRequest().withStackName(stackName)
+		);
+
+		int statusPollingIntervalMs = intervalSeconds * 1000;
+
+		// insert blank line into log
+		log.info("");
+		Status result = waitForCompletion(stackName, statusPollingIntervalMs, log);
+
+		if (!Arrays.asList(StackStatus.DELETE_COMPLETE.toString(), "NO_SUCH_STACK").contains(result.value)) {
+			throw new RuntimeException("delete stack failed: " + result);
+		}
+	}
 
     public void deploy(String stackName, String templateBody,
                        Map<String, String> parameters, int intervalSeconds, String templateUrl) {
@@ -210,7 +227,7 @@ final class CloudFormationDeployer {
         String stackStatus = "Unknown";
         String stackReason = "";
 
-        log.info("waiting for action on  " + stackName);
+        log.info("waiting for action on " + stackName);
         long t = System.currentTimeMillis();
 
         while (true) {
@@ -218,7 +235,6 @@ final class CloudFormationDeployer {
             try {
                 stacks = cloudFormationClient.describeStacks(describeRequest).getStacks();
             } catch (AmazonCloudFormationException e) {
-                log.warn(e.getMessage());
                 stacks = Collections.emptyList();
             }
             if (stacks.isEmpty()) {

--- a/src/main/java/com/github/davidmoten/aws/maven/CloudFormationDeployer.java
+++ b/src/main/java/com/github/davidmoten/aws/maven/CloudFormationDeployer.java
@@ -235,7 +235,7 @@ final class CloudFormationDeployer {
             try {
                 stacks = cloudFormationClient.describeStacks(describeRequest).getStacks();
             } catch (AmazonCloudFormationException e) {
-				log.info(e.getMessage());
+                log.info(e.getMessage());
                 stacks = Collections.emptyList();
             }
             if (stacks.isEmpty()) {

--- a/src/main/java/com/github/davidmoten/aws/maven/CloudFormationDeployer.java
+++ b/src/main/java/com/github/davidmoten/aws/maven/CloudFormationDeployer.java
@@ -235,6 +235,7 @@ final class CloudFormationDeployer {
             try {
                 stacks = cloudFormationClient.describeStacks(describeRequest).getStacks();
             } catch (AmazonCloudFormationException e) {
+				log.info(e.getMessage());
                 stacks = Collections.emptyList();
             }
             if (stacks.isEmpty()) {

--- a/src/main/java/com/github/davidmoten/aws/maven/CloudFormationDestroyMojo.java
+++ b/src/main/java/com/github/davidmoten/aws/maven/CloudFormationDestroyMojo.java
@@ -1,0 +1,33 @@
+package com.github.davidmoten.aws.maven;
+
+import com.amazonaws.services.cloudformation.AmazonCloudFormation;
+import com.amazonaws.services.cloudformation.AmazonCloudFormationClientBuilder;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Destroys CloudFormation stack specified in {@link #stackName} parameter.
+ *
+ * @author Maciej Walkowiak
+ */
+@Mojo(name = "destroyCf")
+public final class CloudFormationDestroyMojo extends AbstractDeployAwsMojo<AmazonCloudFormationClientBuilder, AmazonCloudFormation> {
+
+    @Parameter(property = "stackName")
+    private String stackName;
+
+    @Parameter(property = "intervalSeconds", defaultValue="5")
+    private int intervalSeconds;
+
+    public CloudFormationDestroyMojo() {
+        super(AmazonCloudFormationClientBuilder.standard());
+    }
+
+    @Override
+    protected void execute(AmazonCloudFormation cloudFormationClient) throws MojoFailureException {
+        CloudFormationDeployer deployer = new CloudFormationDeployer(getLog(), cloudFormationClient);
+        deployer.destroy(stackName, intervalSeconds);
+    }
+
+}


### PR DESCRIPTION
I would like to use this plugin for running integration tests, where in pre-integration-test phase stack is created and in post-integration-test stack is destroyed. 

This PR adds a goal to destroy CloudFormation stack.