### PR TITLE
Add goal to remove security groups for particular ports from Beanstalk deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ aws-maven-plugin
 * Deploy a directory to an S3 bucket giving all users read permissions (designed for public S3-hosted websites)
 * Create/Update a stack on CloudFormation
 * Deploy an API Gateway Rest API (CloudFormation does not deploy an api to a stage)
+* Remove security group rules pertaining to particular ports on a Beanstalk deployment (exists because of known inadequacies in cloudformation and default security group creation)
 * Supports java 7+
 * Supports proxy
 
@@ -286,5 +287,45 @@ and call
 ```bash
 mvn package aws:deployRestApi
 ```
+
+### Remove security group rules for particular ports on a Beanstalk deployment
+
+Use the `removePorts` goal:
+
+```xml
+<plugin>
+    <groupId>com.github.davidmoten</groupId>
+    <artifactId>aws-maven-plugin</artifactId>
+    <version>[LATEST_VERSION]</version>
+    <configuration>
+        <!-- Optional authentication configuration. The default credential provider chain is used if the configuration is omitted -->
+        <!-- if you have serverId then exclude awsAccessKey and awsSecretAccessKey parameters -->
+        <serverId>aws</serverId>
+        <!-- if you omit serverId then put explicit keys here as below -->
+        <awsAccessKey>YOUR_AWS_ACCESS_KEY</awsAccessKey>
+        <awsSecretAccessKey>YOUR_AWS_SECRET_ACCESS_KEY</awsSecretAccessKey>
+        
+        <!-- The default region provider chain is used if the region is omitted -->
+        <region>ap-southeast-2</region>
+
+        <removePorts>
+          <removePort>80</removePort>
+        </removePorts>
+                
+        <!-- optional proxy config -->
+        <httpsProxyHost>proxy.mycompany</httpsProxyHost>
+        <httpsProxyPort>8080</httpsProxyPort>
+        <httpsProxyUsername>user</httpsProxyUsername>
+        <httpsProxyPassword>pass</httpsProxyPassword>
+    </configuration>
+</plugin>
+```
+
+and call 
+
+```bash
+mvn package aws:removePorts
+```
+
 
 Nice and easy! (Let me know if you have any problems!)

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Output from a sample run:
 [INFO] getting instance ids for environment blah-blah
 [INFO] getting security group ids for instance ids [i-017071d415b837a6f]
 [INFO] getting security group rules for security group ids [sg-081ae8c0d524d1a99]
-[INFO] removing security group rules {sg-081ae8c0d524d1a99=[sgr-0eb6bfef7cb762f86]}
+[INFO] revoking security group rules {sg-081ae8c0d524d1a99=[sgr-0eb6bfef7cb762f86]}
 [INFO] revoked=true for groupId=sg-081ae8c0d524d1a99, ruleIds=[sgr-0eb6bfef7cb762f86]
 [INFO] ------------------------------------------------------------------------
 [INFO] BUILD SUCCESS

--- a/README.md
+++ b/README.md
@@ -327,5 +327,21 @@ and call
 mvn package aws:removePorts
 ```
 
+Output from a sample run:
+```
+[INFO] getting instance ids for environment blah-blah
+[INFO] getting security group ids for instance ids [i-017071d415b837a6f]
+[INFO] getting security group rules for security group ids [sg-081ae8c0d524d1a99]
+[INFO] removing security group rules {sg-081ae8c0d524d1a99=[sgr-0eb6bfef7cb762f86]}
+[INFO] revoked=true for groupId=sg-081ae8c0d524d1a99, ruleIds=[sgr-0eb6bfef7cb762f86]
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time:  3.357 s
+[INFO] Finished at: 2022-06-22T15:59:59+10:00
+[INFO] ------------------------------------------------------------------------
+
+```
+
 
 Nice and easy! (Let me know if you have any problems!)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ aws-maven-plugin
 * Deploy a directory to an S3 bucket giving all users read permissions (designed for public S3-hosted websites)
 * Create/Update a stack on CloudFormation
 * Deploy an API Gateway Rest API (CloudFormation does not deploy an api to a stage)
-* Remove security group rules pertaining to particular ports on a Beanstalk deployment (exists because of known inadequacies in cloudformation and default security group creation)
+* Remove instance security group rules pertaining to particular ports on a Beanstalk deployment (exists because of known inadequacies in cloudformation and default security group creation)
 * Supports java 7+
 * Supports proxy
 
@@ -288,7 +288,7 @@ and call
 mvn package aws:deployRestApi
 ```
 
-### Remove security group rules for particular ports on a Beanstalk deployment
+### Remove instance security group rules for particular ports on a Beanstalk deployment
 
 Use the `removePorts` goal:
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <aws.sdk.version>1.12.142</aws.sdk.version>
+        <aws.sdk.version>1.12.245</aws.sdk.version>
         <scm.url>scm:git:https://github.com/davidmoten/aws-maven-plugin.git</scm.url>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,11 @@
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-ec2</artifactId>
+            <version>${aws.sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-lambda</artifactId>
             <version>${aws.sdk.version}</version>
         </dependency>

--- a/src/main/java/com/github/davidmoten/aws/maven/BeanstalkDeployMojo.java
+++ b/src/main/java/com/github/davidmoten/aws/maven/BeanstalkDeployMojo.java
@@ -1,11 +1,7 @@
 package com.github.davidmoten.aws.maven;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.Date;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -13,16 +9,8 @@ import org.apache.maven.project.MavenProject;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.services.ec2.AmazonEC2;
-import com.amazonaws.services.ec2.AmazonEC2ClientBuilder;
-import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
-import com.amazonaws.services.ec2.model.DescribeSecurityGroupRulesRequest;
-import com.amazonaws.services.ec2.model.Filter;
-import com.amazonaws.services.ec2.model.RevokeSecurityGroupIngressRequest;
-import com.amazonaws.services.ec2.model.RevokeSecurityGroupIngressResult;
 import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalk;
 import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalkClientBuilder;
-import com.amazonaws.services.elasticbeanstalk.model.DescribeEnvironmentResourcesRequest;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 
@@ -44,68 +32,24 @@ public final class BeanstalkDeployMojo extends AbstractAwsMojo {
     @Parameter(defaultValue = "${project}", required = true)
     private MavenProject project;
 
-    @Parameter(property = "removePorts")
-    private List<String> portsToRemoveValues;
-
     @Override
     protected void execute(AWSCredentialsProvider credentials, String region, Proxy proxy) {
         if (versionLabel == null) {
             versionLabel = createVersionLabel(applicationName, new Date(), project.getVersion());
         }
         ClientConfiguration clientConfiguration = Util.createConfiguration(proxy);
-        AWSElasticBeanstalk beanstalk = AWSElasticBeanstalkClientBuilder.standard().withRegion(region)
-                .withCredentials(credentials).withClientConfiguration(clientConfiguration).build();
-        AmazonEC2 ec2 = AmazonEC2ClientBuilder.standard().withRegion(region).withCredentials(credentials)
-                .withClientConfiguration(clientConfiguration).build();
-        AmazonS3 s3 = AmazonS3ClientBuilder.standard().withRegion(region).withCredentials(credentials)
-                .withClientConfiguration(clientConfiguration).build();
-        BeanstalkDeployer deployer = new BeanstalkDeployer(getLog(), beanstalk, s3);
+        AWSElasticBeanstalk beanstalkClient = AWSElasticBeanstalkClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(credentials)
+                .withClientConfiguration(clientConfiguration)
+                .build();
+        AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(credentials)
+                .withClientConfiguration(clientConfiguration)
+                .build();
+        BeanstalkDeployer deployer = new BeanstalkDeployer(getLog(), beanstalkClient, s3Client);
         deployer.deploy(artifact, applicationName, environmentName, versionLabel);
-
-        // removal of ports logic exists because AWS Beanstalk has lousy support for
-        // removing particular ports from cloudformation deployments. In particular
-        // port 80 from Tomcat image single instance deployments is left open to
-        // anywhere.
-        Set<Integer> portsToRemove = portsToRemoveValues == null ? Collections.emptySet()
-                : portsToRemoveValues.stream().map(x -> Integer.parseInt(x)).collect(Collectors.toSet());
-
-        if (portsToRemove != null && !portsToRemove.isEmpty()) {
-
-            getLog().info("getting instance ids for environment " + environmentName);
-            List<String> instanceIds = beanstalk
-                    .describeEnvironmentResources(
-                            new DescribeEnvironmentResourcesRequest().withEnvironmentName(environmentName)) //
-                    .getEnvironmentResources() //
-                    .getInstances() //
-                    .stream() //
-                    .map(x -> x.getId()) //
-                    .collect(Collectors.toList());
-
-            getLog().info("getting security group ids for instance ids " + instanceIds);
-            List<String> securityGroupIds = ec2
-                    .describeInstances(new DescribeInstancesRequest().withInstanceIds(instanceIds)) //
-                    .getReservations() //
-                    .stream() //
-                    .flatMap(y -> y.getGroups().stream().map(z -> z.getGroupId())) //
-                    .collect(Collectors.toList());
-
-            getLog().info("getting security group rules for security group ids " + securityGroupIds);
-            Filter filter = new Filter();
-            filter.setName("group-id");
-            filter.setValues(securityGroupIds);
-            List<String> securityGroupRuleIds = ec2
-                    .describeSecurityGroupRules(new DescribeSecurityGroupRulesRequest().withFilters(filter)) //
-                    .getSecurityGroupRules() //
-                    .stream() //
-                    .filter(x -> portsToRemove.contains(x.getToPort())) //
-                    .map(x -> x.getSecurityGroupRuleId()) //
-                    .collect(Collectors.toList());
-
-            getLog().info("removing security group rules " + securityGroupRuleIds);
-            RevokeSecurityGroupIngressResult result = ec2.revokeSecurityGroupIngress(
-                    new RevokeSecurityGroupIngressRequest().withSecurityGroupRuleIds(securityGroupRuleIds));
-            getLog().info("returned " + result.getReturn());
-        }
     }
 
     private static String createVersionLabel(String applicationName, Date date, String version) {

--- a/src/main/java/com/github/davidmoten/aws/maven/BeanstalkDeployMojo.java
+++ b/src/main/java/com/github/davidmoten/aws/maven/BeanstalkDeployMojo.java
@@ -2,6 +2,10 @@ package com.github.davidmoten.aws.maven;
 
 import java.io.File;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -9,8 +13,15 @@ import org.apache.maven.project.MavenProject;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.AmazonEC2ClientBuilder;
+import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
+import com.amazonaws.services.ec2.model.DescribeSecurityGroupRulesRequest;
+import com.amazonaws.services.ec2.model.Filter;
+import com.amazonaws.services.ec2.model.RevokeSecurityGroupIngressRequest;
 import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalk;
 import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalkClientBuilder;
+import com.amazonaws.services.elasticbeanstalk.model.DescribeEnvironmentResourcesRequest;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 
@@ -38,18 +49,43 @@ public final class BeanstalkDeployMojo extends AbstractAwsMojo {
             versionLabel = createVersionLabel(applicationName, new Date(), project.getVersion());
         }
         ClientConfiguration clientConfiguration = Util.createConfiguration(proxy);
-        AWSElasticBeanstalk beanstalkClient = AWSElasticBeanstalkClientBuilder.standard()
-                .withRegion(region)
-                .withCredentials(credentials)
-                .withClientConfiguration(clientConfiguration)
-                .build();
-        AmazonS3 s3Client = AmazonS3ClientBuilder.standard()
-                .withRegion(region)
-                .withCredentials(credentials)
-                .withClientConfiguration(clientConfiguration)
-                .build();
-        BeanstalkDeployer deployer = new BeanstalkDeployer(getLog(), beanstalkClient, s3Client);
+        AWSElasticBeanstalk beanstalk = AWSElasticBeanstalkClientBuilder.standard().withRegion(region)
+                .withCredentials(credentials).withClientConfiguration(clientConfiguration).build();
+        AmazonEC2 ec2 = AmazonEC2ClientBuilder.standard().withRegion(region).withCredentials(credentials)
+                .withClientConfiguration(clientConfiguration).build();
+        AmazonS3 s3 = AmazonS3ClientBuilder.standard().withRegion(region).withCredentials(credentials)
+                .withClientConfiguration(clientConfiguration).build();
+        BeanstalkDeployer deployer = new BeanstalkDeployer(getLog(), beanstalk, s3);
         deployer.deploy(artifact, applicationName, environmentName, versionLabel);
+        Set<Integer> ports = new HashSet<Integer>();
+        List<String> instanceIds = beanstalk
+                .describeEnvironmentResources(
+                        new DescribeEnvironmentResourcesRequest().withEnvironmentName(environmentName)) //
+                .getEnvironmentResources() //
+                .getInstances() //
+                .stream() //
+                .map(x -> x.getId()) //
+                .collect(Collectors.toList());
+        List<String> securityGroupIds = ec2
+                .describeInstances(new DescribeInstancesRequest().withInstanceIds(instanceIds)) //
+                .getReservations() //
+                .stream() //
+                .flatMap(y -> y.getGroups().stream().map(z -> z.getGroupId())) //
+                .collect(Collectors.toList());
+
+        Filter filter = new Filter();
+        filter.setName("group-id");
+        filter.setValues(securityGroupIds);
+
+        List<String> securityGroupRuleIds = ec2
+                .describeSecurityGroupRules(new DescribeSecurityGroupRulesRequest().withFilters(filter)) //
+                .getSecurityGroupRules() //
+                .stream() //
+                .filter(x -> ports.contains(x.getToPort())) //
+                .map(x -> x.getSecurityGroupRuleId()) //
+                .collect(Collectors.toList());
+
+        ec2.revokeSecurityGroupIngress(new RevokeSecurityGroupIngressRequest().withSecurityGroupRuleIds(securityGroupRuleIds));
     }
 
     private static String createVersionLabel(String applicationName, Date date, String version) {

--- a/src/main/java/com/github/davidmoten/aws/maven/BeanstalkRemovePortsMojo.java
+++ b/src/main/java/com/github/davidmoten/aws/maven/BeanstalkRemovePortsMojo.java
@@ -35,12 +35,11 @@ public final class BeanstalkRemovePortsMojo extends AbstractAwsMojo {
 
     @Override
     protected void execute(AWSCredentialsProvider credentials, String region, Proxy proxy) {
-        
+
         ClientConfiguration clientConfiguration = Util.createConfiguration(proxy);
         AWSElasticBeanstalk beanstalk = AWSElasticBeanstalkClientBuilder //
                 .standard() //
-                .withRegion(region)
-                .withCredentials(credentials) //
+                .withRegion(region).withCredentials(credentials) //
                 .withClientConfiguration(clientConfiguration) //
                 .build();
         AmazonEC2 ec2 = AmazonEC2ClientBuilder //
@@ -68,7 +67,7 @@ public final class BeanstalkRemovePortsMojo extends AbstractAwsMojo {
                     .stream() //
                     .map(x -> x.getId()) //
                     .collect(Collectors.toList());
-            if (instanceIds.isEmpty() ) {
+            if (instanceIds.isEmpty()) {
                 getLog().info("no instances found");
                 return;
             }
@@ -77,7 +76,12 @@ public final class BeanstalkRemovePortsMojo extends AbstractAwsMojo {
                     .describeInstances(new DescribeInstancesRequest().withInstanceIds(instanceIds)) //
                     .getReservations() //
                     .stream() //
-                    .flatMap(y -> y.getGroups().stream().map(z -> z.getGroupId())) //
+                    .flatMap(y -> y //
+                            .getInstances() //
+                            .stream() //
+                            .flatMap(z -> z.getNetworkInterfaces().stream()) //
+                            .flatMap(z -> z.getGroups().stream())
+                            .map(z -> z.getGroupId())) //
                     .collect(Collectors.toList());
             if (securityGroupIds.isEmpty()) {
                 getLog().info("no security groups found");

--- a/src/main/java/com/github/davidmoten/aws/maven/BeanstalkRemovePortsMojo.java
+++ b/src/main/java/com/github/davidmoten/aws/maven/BeanstalkRemovePortsMojo.java
@@ -70,6 +70,7 @@ public final class BeanstalkRemovePortsMojo extends AbstractAwsMojo {
                     .collect(Collectors.toList());
             if (instanceIds.isEmpty() ) {
                 getLog().info("no instances found");
+                return;
             }
             getLog().info("getting security group ids for instance ids " + instanceIds);
             List<String> securityGroupIds = ec2
@@ -80,6 +81,7 @@ public final class BeanstalkRemovePortsMojo extends AbstractAwsMojo {
                     .collect(Collectors.toList());
             if (securityGroupIds.isEmpty()) {
                 getLog().info("no security groups found");
+                return;
             }
             getLog().info("getting security group rules for security group ids " + securityGroupIds);
             Filter filter = new Filter();
@@ -95,6 +97,7 @@ public final class BeanstalkRemovePortsMojo extends AbstractAwsMojo {
 
             if (securityGroupRuleIds.isEmpty()) {
                 getLog().info("no security group rules found");
+                return;
             }
             getLog().info("removing security group rules " + securityGroupRuleIds);
             RevokeSecurityGroupIngressResult result = ec2.revokeSecurityGroupIngress(

--- a/src/main/java/com/github/davidmoten/aws/maven/BeanstalkRemovePortsMojo.java
+++ b/src/main/java/com/github/davidmoten/aws/maven/BeanstalkRemovePortsMojo.java
@@ -116,7 +116,7 @@ public final class BeanstalkRemovePortsMojo extends AbstractAwsMojo {
             securityGroupRules.forEach((groupId, ruleIds) -> {
                 RevokeSecurityGroupIngressResult result = ec2.revokeSecurityGroupIngress(
                         new RevokeSecurityGroupIngressRequest().withGroupId(groupId).withSecurityGroupRuleIds(ruleIds));
-                getLog().info("returned " + result.getReturn() + " for groupId=" + groupId + ", ruleIds=" + ruleIds);
+                getLog().info("revoked=" + result.getReturn() + " for groupId=" + groupId + ", ruleIds=" + ruleIds);
             });
         }
     }

--- a/src/main/java/com/github/davidmoten/aws/maven/BeanstalkRemovePortsMojo.java
+++ b/src/main/java/com/github/davidmoten/aws/maven/BeanstalkRemovePortsMojo.java
@@ -1,0 +1,128 @@
+package com.github.davidmoten.aws.maven;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.AmazonEC2ClientBuilder;
+import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
+import com.amazonaws.services.ec2.model.DescribeSecurityGroupRulesRequest;
+import com.amazonaws.services.ec2.model.Filter;
+import com.amazonaws.services.ec2.model.RevokeSecurityGroupIngressRequest;
+import com.amazonaws.services.ec2.model.RevokeSecurityGroupIngressResult;
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalk;
+import com.amazonaws.services.elasticbeanstalk.AWSElasticBeanstalkClientBuilder;
+import com.amazonaws.services.elasticbeanstalk.model.DescribeEnvironmentResourcesRequest;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Mojo(name = "deploy")
+public final class BeanstalkDeployMojo extends AbstractAwsMojo {
+
+    @Parameter(property = "applicationName")
+    private String applicationName;
+
+    @Parameter(property = "environmentName")
+    private String environmentName;
+
+    @Parameter(property = "artifact")
+    private File artifact;
+
+    @Parameter(property = "versionLabel")
+    private String versionLabel;
+
+    @Parameter(defaultValue = "${project}", required = true)
+    private MavenProject project;
+
+    @Parameter(property = "removePorts")
+    private List<String> portsToRemoveValues;
+
+    @Override
+    protected void execute(AWSCredentialsProvider credentials, String region, Proxy proxy) {
+        if (versionLabel == null) {
+            versionLabel = createVersionLabel(applicationName, new Date(), project.getVersion());
+        }
+        ClientConfiguration clientConfiguration = Util.createConfiguration(proxy);
+        AWSElasticBeanstalk beanstalk = AWSElasticBeanstalkClientBuilder //
+                .standard() //
+                .withRegion(region)
+                .withCredentials(credentials) //
+                .withClientConfiguration(clientConfiguration) //
+                .build();
+        AmazonEC2 ec2 = AmazonEC2ClientBuilder //
+                .standard() //
+                .withRegion(region) //
+                .withCredentials(credentials) //
+                .withClientConfiguration(clientConfiguration) //
+                .build();
+        AmazonS3 s3 = AmazonS3ClientBuilder //
+                .standard() //
+                .withRegion(region) //
+                .withCredentials(credentials)
+                .withClientConfiguration(clientConfiguration) //
+                .build();
+        BeanstalkDeployer deployer = new BeanstalkDeployer(getLog(), beanstalk, s3);
+        deployer.deploy(artifact, applicationName, environmentName, versionLabel);
+
+        // removal of ports logic exists because AWS Beanstalk has lousy support for
+        // removing particular ports from cloudformation deployments. In particular
+        // port 80 from Tomcat image single instance deployments is left open to
+        // anywhere.
+        Set<Integer> portsToRemove = portsToRemoveValues == null ? Collections.emptySet()
+                : portsToRemoveValues.stream().map(x -> Integer.parseInt(x)).collect(Collectors.toSet());
+
+        if (portsToRemove != null && !portsToRemove.isEmpty()) {
+
+            getLog().info("getting instance ids for environment " + environmentName);
+            List<String> instanceIds = beanstalk
+                    .describeEnvironmentResources(
+                            new DescribeEnvironmentResourcesRequest().withEnvironmentName(environmentName)) //
+                    .getEnvironmentResources() //
+                    .getInstances() //
+                    .stream() //
+                    .map(x -> x.getId()) //
+                    .collect(Collectors.toList());
+
+            getLog().info("getting security group ids for instance ids " + instanceIds);
+            List<String> securityGroupIds = ec2
+                    .describeInstances(new DescribeInstancesRequest().withInstanceIds(instanceIds)) //
+                    .getReservations() //
+                    .stream() //
+                    .flatMap(y -> y.getGroups().stream().map(z -> z.getGroupId())) //
+                    .collect(Collectors.toList());
+
+            getLog().info("getting security group rules for security group ids " + securityGroupIds);
+            Filter filter = new Filter();
+            filter.setName("group-id");
+            filter.setValues(securityGroupIds);
+            List<String> securityGroupRuleIds = ec2
+                    .describeSecurityGroupRules(new DescribeSecurityGroupRulesRequest().withFilters(filter)) //
+                    .getSecurityGroupRules() //
+                    .stream() //
+                    .filter(x -> portsToRemove.contains(x.getToPort())) //
+                    .map(x -> x.getSecurityGroupRuleId()) //
+                    .collect(Collectors.toList());
+
+            getLog().info("removing security group rules " + securityGroupRuleIds);
+            RevokeSecurityGroupIngressResult result = ec2.revokeSecurityGroupIngress(
+                    new RevokeSecurityGroupIngressRequest().withSecurityGroupRuleIds(securityGroupRuleIds));
+            getLog().info("returned " + result.getReturn());
+        }
+    }
+
+    private static String createVersionLabel(String applicationName, Date date, String version) {
+        // construct version label using application name and dateTime
+        return applicationName + "_" + version + "_" + Util.formatDateTime(date);
+    }
+
+}

--- a/src/main/java/com/github/davidmoten/aws/maven/BeanstalkRemovePortsMojo.java
+++ b/src/main/java/com/github/davidmoten/aws/maven/BeanstalkRemovePortsMojo.java
@@ -116,7 +116,7 @@ public final class BeanstalkRemovePortsMojo extends AbstractAwsMojo {
             securityGroupRules.forEach((groupId, ruleIds) -> {
                 RevokeSecurityGroupIngressResult result = ec2.revokeSecurityGroupIngress(
                         new RevokeSecurityGroupIngressRequest().withGroupId(groupId).withSecurityGroupRuleIds(ruleIds));
-                getLog().info("returned " + result.getReturn() + "for groupId=" + groupId + ", ruleIds=" + ruleIds);
+                getLog().info("returned " + result.getReturn() + " for groupId=" + groupId + ", ruleIds=" + ruleIds);
             });
         }
     }

--- a/src/main/java/com/github/davidmoten/aws/maven/BeanstalkRemovePortsMojo.java
+++ b/src/main/java/com/github/davidmoten/aws/maven/BeanstalkRemovePortsMojo.java
@@ -112,7 +112,7 @@ public final class BeanstalkRemovePortsMojo extends AbstractAwsMojo {
                 getLog().info("no security group rules found");
                 return;
             }
-            getLog().info("removing security group rules " + securityGroupRules);
+            getLog().info("revoking security group rules " + securityGroupRules);
             securityGroupRules.forEach((groupId, ruleIds) -> {
                 RevokeSecurityGroupIngressResult result = ec2.revokeSecurityGroupIngress(
                         new RevokeSecurityGroupIngressRequest().withGroupId(groupId).withSecurityGroupRuleIds(ruleIds));


### PR DESCRIPTION
This PR is due to a weakness in CloudFormation deployments of AWS Java Tomcat images to Beanstalk whereby a default security group is always added for port 80 that is open to anywhere.